### PR TITLE
chore: trigger release by tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,26 @@
+name: Release
+
+# This workflow uses Release Please to automatically analyze
+# and create a release PR when a commit is pushed to the main branch.
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Analyse commits and open PR or prepare release 📦
+        uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          # We need to use PAT in order to trigger the release workflow
+          token: ${{ secrets.PAT_GITHUB_TOKEN }}
+          release-type: node
+          package-name: pubsub-http-handler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Use Node.js LTS ✨
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+
+      - name: Install dependencies 📦️
+        run: yarn install --immutable
+
+      - name: Build 🔨
+        run: yarn build
+
+      - name: Publish 🚀
+        run: yarn publish
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Build 🔨
         run: yarn build
 
-      - name: Publish 🚀
-        run: yarn publish
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: simenandre/publish-with-yarn-classic@v1
+        with:
+          npm-auth-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,12 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
-        id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
-
       - uses: actions/checkout@v3
 
       - name: Setup Node


### PR DESCRIPTION
By experience it's useful to have release-please, but it has caused some extra work for contributors. To try to make it easier and more accessible, we should allow for releases based on tag as well. This fixes that!

closes #283 
